### PR TITLE
allow null for FailedSyncItemNextTime

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <Authors>$(Company)</Authors>
     <Copyright>Copyright © $(Company) $([System.DateTime]::Now.Year)</Copyright>
     <Trademark>$(Company)™</Trademark>
-    <VersionPrefix>1.0.1</VersionPrefix>
+    <VersionPrefix>1.0.2</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <Authors>$(Company)</Authors>
     <Copyright>Copyright © $(Company) $([System.DateTime]::Now.Year)</Copyright>
     <Trademark>$(Company)™</Trademark>
-    <VersionPrefix>1.0.2</VersionPrefix>
+    <VersionPrefix>1.0.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
 

--- a/src/Kentico.Xperience.CRM.Common/Admin/CRMModuleInstaller.cs
+++ b/src/Kentico.Xperience.CRM.Common/Admin/CRMModuleInstaller.cs
@@ -191,7 +191,8 @@ internal class CRMModuleInstaller : ICRMModuleInstaller
             Visible = false,
             Precision = 0,
             DataType = "datetime",
-            Enabled = true
+            Enabled = true,
+            AllowEmpty = true
         };
         formInfo.AddFormItem(formItem);
 


### PR DESCRIPTION
# Motivation

FailedSyncItemNextTime should allow null, in current release it throws error after max 10 sync tries and update of db item failing periodically because NULL cannot be set. 

# Problem
In old database with FailedSyncItem already initilialized problem has to be resolved manually because CombineWithForm does not resolve this definiton update, so it isn't updated in installer.